### PR TITLE
Pc 325 pom update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.phenotips</groupId>
+  <groupId>org.phenomecentral</groupId>
   <artifactId>phenomeCentral-automation</artifactId>
   <version>1.0-SNAPSHOT</version>
 
@@ -62,7 +62,7 @@
   </build>
 
   <dependencies>
-    <!-- Merge code from here -->
+
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
@@ -97,15 +97,6 @@
       <version>2.10.0</version>
     </dependency>
 
-
-    <!-- https://mvnrepository.com/artifact/junit/junit -->
-    <!--<dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
-        <scope>test</scope>
-    </dependency> -->
-    <!-- Merge code from here END -->
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.phenomeCentral.brianli</groupId>
+  <groupId>org.phenotips</groupId>
   <artifactId>phenomeCentral-automation</artifactId>
   <version>1.0-SNAPSHOT</version>
 
@@ -42,8 +42,10 @@
           </argLine>
 
           <suiteXmlFiles>
-            <!-- Specify POM file through command line using -Dsurefire.suiteXmlFiles=... -->
-            <!--  <suiteXmlFile>src/main/java/org/phenotips/testcases/xml/AllTests.xml</suiteXmlFile> -->
+            <!-- Specify POM file through command line using -Dsurefire.suiteXmlFiles=...
+                  Default to not run any tests so that doesn't affect mvn build of phenomecentral.org -->
+            <!--  <suiteXmlFile>src/test/java/org/phenotips/endtoendtests/testcases/xml/AllTests.xml</suiteXmlFile> -->
+            <suiteXmlFile>src/test/java/org/phenotips/endtoendtests/testcases/xml/NoTests.xml</suiteXmlFile>
           </suiteXmlFiles>
         </configuration>
 

--- a/src/test/java/org/phenotips/endtoendtests/testcases/xml/NoTests.xml
+++ b/src/test/java/org/phenotips/endtoendtests/testcases/xml/NoTests.xml
@@ -1,0 +1,7 @@
+<suite name="NoTests">
+  <test name="NoTest">
+    <classes>
+
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
- Specify that a NOP e2e test to be run by default during `mvn test` and `mvn install` life cycle. The actual Selenium tests should only be run when explicitly asked for, such as using the `runIntegrationTests.sh` script, running directly on IDE, or by running `mvn test -Dsurefire.suiteXmlFiles=src/main/java/org/phenotips/endtoendtests/testcases/xml/AllTests.xml`
- `mvn install` or `mvn test` by default for this project will always pass tests as there are no tests to run in the first place.